### PR TITLE
feat: add uninstall.sh and README documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,21 @@ Deduplication is by exact title match against open issues. GitHub is the sole so
 
 Run logs are written to `~/.nightshift/logs/YYYY-MM-DD.log` with timestamped entries per repo and agent, plus a summary line at the end of each run.
 
+## Uninstalling
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/lewisharper/nightshift/main/uninstall.sh | bash -s -- -y
+```
+
+Or, if you want an interactive confirmation prompt:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/lewisharper/nightshift/main/uninstall.sh -o uninstall.sh
+bash uninstall.sh
+```
+
+This removes the `nightshift` binary, the agent prompts, the config and logs directory, and the cron job. It does not touch GitHub labels, AI CLI installations, or AI CLI configuration.
+
 ## Licence
 
 See [LICENCE.md](LICENCE.md).

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BINARY="$HOME/.local/bin/nightshift"
+SHARE_DIR="$HOME/.local/share/nightshift"
+CONFIG_DIR="$HOME/.nightshift"
+
+YES=0
+for arg in "$@"; do
+    case "$arg" in
+        -y|--yes) YES=1 ;;
+    esac
+done
+
+if [ "$YES" -eq 0 ]; then
+    if [ ! -t 0 ]; then
+        echo "Error: stdin is not a TTY. Run with -y to proceed non-interactively." >&2
+        exit 1
+    fi
+
+    echo "This will remove the following nightshift components:"
+    echo "  $BINARY"
+    echo "  $SHARE_DIR/"
+    echo "  $CONFIG_DIR/"
+    echo "  nightshift cron entry"
+    echo ""
+    printf "Continue? [y/N] "
+    read -r reply
+    case "$reply" in
+        y|Y) ;;
+        *) echo "Aborted."; exit 0 ;;
+    esac
+fi
+
+echo "Uninstalling nightshift..."
+
+# Remove cron entry
+if crontab -l 2>/dev/null | grep -q "nightshift run"; then
+    crontab -l 2>/dev/null | grep -v "nightshift run" | crontab -
+    echo "  Removed cron entry."
+fi
+
+# Remove binary
+if [ -f "$BINARY" ]; then
+    rm -f "$BINARY"
+    echo "  Removed $BINARY"
+fi
+
+# Remove prompts directory
+if [ -d "$SHARE_DIR" ]; then
+    rm -rf "$SHARE_DIR"
+    echo "  Removed $SHARE_DIR/"
+fi
+
+# Remove config and logs directory
+if [ -d "$CONFIG_DIR" ]; then
+    rm -rf "$CONFIG_DIR"
+    echo "  Removed $CONFIG_DIR/"
+fi
+
+echo ""
+echo "nightshift has been uninstalled."


### PR DESCRIPTION
## Summary

- Adds `uninstall.sh` to the repo root — a standalone bash script that cleanly removes all nightshift installation artifacts
- Updates `README.md` with an "Uninstalling" section covering the curl one-liner and a manual alternative

## What the script does

- Accepts `-y` / `--yes` to skip the interactive prompt (for automation/non-interactive use)
- Detects missing TTY: exits non-zero with a clear error if stdin is not a TTY and `-y` is absent
- Prints a warning listing all components to be removed before prompting `[y/N]` (defaults to no)
- Removes in order: cron entry, binary (`~/.local/bin/nightshift`), prompts dir (`~/.local/share/nightshift/`), config/logs dir (`~/.nightshift/`)
- Skips any component that is already absent — idempotent and safe to run multiple times
- Does not touch GitHub labels, AI CLI installations, or AI CLI configuration

Closes #3